### PR TITLE
Allow nodeSelector on Crusoe CCM deployment

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.7'
 
       - name: Install chart-testing
         uses: helm/chart-testing-action@v2.0.1

--- a/charts/crusoe-cloud-controller-manager/Chart.yaml
+++ b/charts/crusoe-cloud-controller-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: crusoe-cloud-controller-manager
 description: A Helm chart for the Crusoe Cloud Controller Manager
 
 type: application
-version: 0.1.3
+version: 0.2.0
 appVersion: "v0.1.4"
 
 kubeVersion: ">=1.17.0-0"

--- a/charts/crusoe-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/crusoe-cloud-controller-manager/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
                     values:
                       - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
+      {{- with .Values.controller.crusoeccm.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # needed to remove dependency on CNI
       hostNetwork: true
       containers:

--- a/charts/crusoe-cloud-controller-manager/values.yaml
+++ b/charts/crusoe-cloud-controller-manager/values.yaml
@@ -14,6 +14,7 @@ controller:
       imagePullPolicy: IfNotPresent
     provider: "crusoe"
     clusterName: "test-cluster"
+    nodeSelector: {}
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Allow optional setting of `nodeSelector` on the Crusoe CCM deployment.